### PR TITLE
Infer modal props type for useModal

### DIFF
--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1,9 +1,9 @@
-type UseModal = (
+type UseModal = <p = any>(
   key: string,
-  modal: PheliaModal,
+  modal: PheliaModal<p>,
   onSubmit?: (event: SubmitEvent) => void | Promise<void>,
   onCancel?: (event: InteractionEvent) => void | Promise<void>
-) => (props?: any) => Promise<void>;
+) => (props?: p) => Promise<void>;
 
 type UseState = <t = any>(
   key: string,


### PR DESCRIPTION
I think it might also make sense to change the default `<p = any>` usages, so you actually have to specify the prop types? But for now this works as it is, so at least you don't need to specify the types twice 🙂 