### PR TITLE
bind processOption to the class

### DIFF
--- a/src/core/phelia.ts
+++ b/src/core/phelia.ts
@@ -600,13 +600,13 @@ export class Phelia {
       this.processSubmission(payload);
     });
 
-    adapter.action({ type: "block_suggestion" }, this.processOption);
+    adapter.action({ type: "block_suggestion" }, this.processOption.bind(this));
 
     adapter.action(new RegExp(/.*/), async payload => {
       this.processAction(payload);
     });
 
-    adapter.options(new RegExp(/.*/), this.processOption);
+    adapter.options(new RegExp(/.*/), this.processOption.bind(this));
 
     return adapter.requestListener();
   }


### PR DESCRIPTION
The way the class method was passed to the adapter lost the binding to the class. Any usage of `this` would result in no options being displayed.