### PR TITLE
Feat/update container

### DIFF
--- a/src/core/components.tsx
+++ b/src/core/components.tsx
@@ -1352,6 +1352,9 @@ interface HomeProps {
 
   /** A callback ran when home app is loaded. */
   onLoad?: (event: InteractionEvent) => Promise<void> | void;
+
+  /** A callback ran when home app is updated. */
+  onUpdate?: (event: InteractionEvent) => Promise<void> | void;
 }
 
 /**

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -131,6 +131,8 @@ export interface PheliaMessageContainer {
   type: "message" | "modal" | "home";
   /** An id for the surface */
   viewID: string;
+  /** A user who interacts with the message */
+  user: SlackUser;
 }
 
 export type MessageCallback = () => PheliaMessage[];

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -70,7 +70,7 @@ export interface Action {
   event: InteractionEvent;
 
   /** The type of action */
-  type?: "interaction" | "onload";
+  type?: "interaction" | "onload" | "onupdate";
 }
 
 export interface PheliaMessageMetadata {

--- a/src/core/phelia.ts
+++ b/src/core/phelia.ts
@@ -45,7 +45,7 @@ export class Phelia {
     message: PheliaMessage<p>,
     channel: string,
     props: p = null
-  ) {
+  ): Promise<string> {
     const initializedState: { [key: string]: any } = {};
 
     /** A hook to create some state for a component */
@@ -66,7 +66,12 @@ export class Phelia {
       React.createElement(message, { useState, props, useModal })
     );
 
-    const { channel: channelID, ts } = await this.client.chat.postMessage({
+    // only can return a user id here, need to enhance it using methods.user
+    const {
+      channel: channelID,
+      ts,
+      message: sentMessageData,
+    } = await this.client.chat.postMessage({
       ...messageData,
       channel,
     });
@@ -80,9 +85,60 @@ export class Phelia {
         type: "message",
         name: message.name,
         state: initializedState,
+        user: { id: (sentMessageData as any).user },
         props,
         channelID,
         ts,
+      })
+    );
+
+    return messageKey;
+  }
+
+  async updateMessage<p>(key: string, props: p) {
+    const rawMessageContainer = await Phelia.Storage.get(key);
+    if (!rawMessageContainer) {
+      throw TypeError(`Could not find a message with key ${key}.`);
+    }
+
+    const container: PheliaMessageContainer = JSON.parse(rawMessageContainer);
+
+    /** A hook to create some state for a component */
+    function useState<t>(key: string): [t, (value: t) => void] {
+      return [
+        container.state[key],
+        (newState: t) => (container.state[key] = newState),
+      ];
+    }
+
+    /** A hook to create a modal for a component */
+    function useModal(): (title: string, props?: any) => Promise<void> {
+      return async () => null;
+    }
+
+    const message = await render(
+      React.createElement(this.messageCache.get(container.name) as any, {
+        useState,
+        useModal,
+        props,
+      })
+    );
+
+    await this.client.chat.update({
+      ...message,
+      channel: container.channelID,
+      ts: container.ts,
+    });
+
+    await Phelia.Storage.set(
+      container.viewID,
+      JSON.stringify({
+        message: JSON.stringify(message),
+        name: this.homeComponent.name,
+        state: container.state,
+        type: "home",
+        viewID: container.viewID,
+        user: container.user,
       })
     );
   }
@@ -187,6 +243,7 @@ export class Phelia {
             state: initializedState,
             type: "home",
             viewID,
+            user,
           })
         );
       } else {
@@ -242,6 +299,7 @@ export class Phelia {
             state: container.state,
             type: "home",
             viewID: container.viewID,
+            user,
           })
         );
       }
@@ -260,6 +318,7 @@ export class Phelia {
     }
 
     const container: PheliaMessageContainer = JSON.parse(rawMessageContainer);
+    const user = payload.user;
 
     /** A hook to create some state for a component */
     function useState<t>(
@@ -316,6 +375,7 @@ export class Phelia {
             state: initializedState,
             type: "modal",
             viewID,
+            user,
           })
         );
       };
@@ -327,11 +387,11 @@ export class Phelia {
           useState,
           props: container.props,
           useModal,
-          user: container.type === "home" ? payload.user : undefined,
+          user: container.type === "home" ? user : undefined,
         }),
         {
           value: action.action_id,
-          event: generateEvent(action, payload.user),
+          event: generateEvent(action, user),
           type: "interaction",
         }
       );
@@ -374,6 +434,7 @@ export class Phelia {
       JSON.stringify({
         ...container,
         message: JSON.stringify(message),
+        user,
       })
     );
   }
@@ -549,6 +610,7 @@ export class Phelia {
       viewContainer.invokerKey,
       JSON.stringify({
         ...invokerContainer,
+        user: payload.user,
         message: JSON.stringify(message),
       })
     );

--- a/src/core/reconciler.ts
+++ b/src/core/reconciler.ts
@@ -213,6 +213,14 @@ class HostConfig
       return true;
     }
 
+    if (rootContainerInstance.action?.type === "onupdate" && props.onUpdate) {
+      rootContainerInstance.promises.push(
+        props.onUpdate(rootContainerInstance.action.event)
+      );
+
+      return true;
+    }
+
     if (
       rootContainerInstance.action &&
       props.action === rootContainerInstance.action.value

--- a/src/example/example-messages/home-app.tsx
+++ b/src/example/example-messages/home-app.tsx
@@ -13,15 +13,20 @@ export function HomeApp({ useState, useModal, user }: PheliaHomeProps) {
   const [counter, setCounter] = useState("counter", 0);
   const [loaded, setLoaded] = useState("loaded", 0);
   const [form, setForm] = useState("form");
+  const [updated, setUpdated] = useState("updated", false);
 
   const openModal = useModal("modal", MyModal, (event) =>
     setForm(JSON.stringify(event.form, null, 2))
   );
 
   return (
-    <Home onLoad={() => setLoaded(loaded + 1)}>
+    <Home
+      onLoad={() => setLoaded(loaded + 1)}
+      onUpdate={() => setUpdated(true)}
+    >
       <Section>
         <Text emoji>Hey there {user.username} :wave:</Text>
+        <Text type="mrkdwn">*Updated:* {String(updated)}</Text>
         <Text type="mrkdwn">*Counter:* {counter}</Text>
         <Text type="mrkdwn">*Loaded:* {loaded}</Text>
       </Section>

--- a/src/example/example-messages/modal-example.tsx
+++ b/src/example/example-messages/modal-example.tsx
@@ -13,7 +13,7 @@ import {
   Section,
   Text,
   TextField,
-  PheliaModalProps
+  PheliaModalProps,
 } from "../../core";
 
 export function MyModal({ useState }: PheliaModalProps) {
@@ -63,14 +63,22 @@ export function MyModal({ useState }: PheliaModalProps) {
 
 type State = "submitted" | "canceled" | "init";
 
-export function ModalExample({ useModal, useState }: PheliaMessageProps) {
+type Props = {
+  name: string;
+};
+
+export function ModalExample({
+  useModal,
+  useState,
+  props,
+}: PheliaMessageProps<Props>) {
   const [state, setState] = useState<State>("state", "init");
   const [form, setForm] = useState("form", "");
 
   const openModal = useModal(
     "modal",
     MyModal,
-    form => {
+    (form) => {
       setState("submitted");
       setForm(JSON.stringify(form, null, 2));
     },
@@ -79,6 +87,10 @@ export function ModalExample({ useModal, useState }: PheliaMessageProps) {
 
   return (
     <Message text="A modal example">
+      <Section>
+        <Text type="mrkdwn">hey {props.name}!</Text>
+      </Section>
+
       {state === "canceled" && (
         <Section>
           <Text emoji>:no_good: why'd you have to do that</Text>

--- a/src/example/server.ts
+++ b/src/example/server.ts
@@ -88,8 +88,11 @@ slackEvents.on("app_home_opened", client.appHomeHandler(HomeApp));
 
 app.use("/events", slackEvents.requestListener());
 
-// This is how you post a message....
-client.postMessage(ModalExample, "@max", { name: "Max" });
+(async () => {
+  const key = await client.postMessage(ModalExample, "@max", { name: "Max" });
+
+  await client.updateMessage(key, { name: "me but laters" });
+})();
 
 app.listen(port, () =>
   console.log(`Example app listening at http://localhost:${port}`)


### PR DESCRIPTION
Allows messages and home apps to be updated.

## Messages

Keep a reference to the `messageKey` returned by `client.postMessage()` to update the message with different `props` at a later date.
```ts
const messageKey = await client.postMessage(ModalExample, "@max", { name: "Max" });
...
await client.updateMessage(key, { name: "new name" });
```

## Home App

Provide a callback to `client.appHomeHandler` which receives a `homeKey` and `user` object whenever a user **views** your Home App (may happen multiple times). At a later date, run `client.updateHome(homeKey)` to run the Home component's `onUpdate` and re-render

```ts
slackEvents.on("app_home_opened", client.appHomeHandler(HomeApp, (homeKey, user) => {
  saveHomeWithUser(homeKey, user)
}));
...

await client.updateHome(homeKey)
```
https://github.com/maxchehab/phelia/blob/ac5f0398b5d05e46f831125796ac0f3771f1610f/src/example/example-messages/home-app.tsx#L23-L49
