### PR TITLE
[RFC][Feature] Add ability to open modal using triggerID from command.

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -328,6 +328,28 @@ _This requires use of Slack's SDK `@slack/events-api`_
 
 With this setup, whenever a user opens the Home tab it will display your Home App accordingly.
 
+## Opening Modals
+
+Modals can be opened in two ways:
+
+1. By use of the `useModal` hook in a component.
+2. In response to a user command or action within Slack.
+
+When responding to user action outside a phelia component, one can record the `trigger_id` sent by slack in response to a command and use it to open a modal:
+
+```ts
+
+// In response to some slash command from the user.
+const triggerID = slackCommandPayload.trigger_id;
+const client = new Phelia(process.env.SLACK_TOKEN);
+
+await client.openModal(
+  MyModal,
+  triggerID,
+  { // props },
+);
+```
+
 ## Injected Properties
 
 Depending on which type of component you are building, Phelia will inject a collection of functions and properties into your components function.

--- a/src/core/components.tsx
+++ b/src/core/components.tsx
@@ -516,7 +516,7 @@ export const Message = (props: MessageProps) => (
   />
 );
 
-interface ModalProps {
+interface BaseModalProps {
   /** Array of Actions, Context, Divider, ImageBlock, Input, or Section components	 */
   children: PheliaChildren;
   /** The title of the modal. */
@@ -542,6 +542,26 @@ interface ModalProps {
    */ 
   onCancel?: (event: InteractionEvent) => Promise<void>;
 }
+
+type RootModalProps = BaseModalProps & {
+  /** A modal subtype indicating this modal was opened by a shortcut or command. */
+  type: "root";
+  /**
+   * An optional callback that executes when the modal is submitted.
+   */
+  onSubmit?: (event: SubmitEvent) => Promise<void>;
+  /**
+   * An optional callback that executes when the modal is canceled.
+   */
+  onCancel?: (event: InteractionEvent) => Promise<void>;
+}
+
+type InlineModalProps = BaseModalProps & {
+  /** A modal subtype indicating this modal was opened by another component. */
+  type?: "inline";
+};
+
+type ModalProps = RootModalProps | InlineModalProps;
 
 /**
  * Modals provide focused spaces ideal for requesting and collecting data from users,

--- a/src/core/components.tsx
+++ b/src/core/components.tsx
@@ -19,6 +19,7 @@ import {
   SearchOptionsEvent,
   SelectDateEvent,
   SelectOptionEvent,
+  SubmitEvent,
 } from "./interfaces";
 
 type PheliaChild = false | null | undefined | ReactElement | ReactElement[];
@@ -531,6 +532,15 @@ interface ModalProps {
    * at the bottom-right of the view. Max length of 24 characters.
    */
   close?: ReactElement | string;
+
+  /**
+   * An optional callback that executes when the modal is submitted.
+   */ 
+  onSubmit?: (event: SubmitEvent) => Promise<void>;
+  /**
+   * An optional callback that executes when the modal is canceled.
+   */ 
+  onCancel?: (event: InteractionEvent) => Promise<void>;
 }
 
 /**

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -131,6 +131,11 @@ export interface PheliaMessageContainer {
   type: "message" | "modal" | "home";
   /** When `type` === message: whether the message is ephemeral or not */
   isEphemeral?: true;
+  /**
+   * When `type` === modal, whether the modal was initiated inside another
+   * component (by use of `useModal`) or by a command or shortcut.
+   */
+  modalType: "inline" | "root";
   /** An id for the surface */
   viewID: string;
   /** A user who interacts with the message */

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -70,7 +70,7 @@ export interface Action {
   event: InteractionEvent;
 
   /** The type of action */
-  type?: "interaction" | "onload" | "onupdate";
+  type?: "interaction" | "onload" | "onupdate" | "oncancel" | "onsubmit";
 }
 
 export interface PheliaMessageMetadata {

--- a/src/core/phelia.ts
+++ b/src/core/phelia.ts
@@ -48,7 +48,7 @@ export class Phelia {
   ): Promise<void> {
     const initializedState: { [key: string]: any } = {};
 
-    /** foo */
+    /** A hook to create some state for a component */
     function useState<t>(
       key: string,
       initialValue?: t

--- a/src/core/phelia.ts
+++ b/src/core/phelia.ts
@@ -572,7 +572,7 @@ export class Phelia {
       viewContainer.invokerKey
     );
 
-    if (viewContainer.invokerKey !== null && !rawInvokerContainer) {
+    if (!rawInvokerContainer) {
       throw new Error(
         `Could not find Message Container with key ${viewContainer.invokerKey} in storage.`
       );

--- a/src/core/phelia.ts
+++ b/src/core/phelia.ts
@@ -79,6 +79,7 @@ export class Phelia {
         props,
         state: initializedState,
         type: "modal",
+        modalType: "root",
         viewID,
       })
     );
@@ -552,6 +553,7 @@ export class Phelia {
             props,
             state: initializedState,
             type: "modal",
+            modalType: "inline",
             viewID,
             user,
           })
@@ -753,13 +755,14 @@ export class Phelia {
       return async () => null;
     }
 
+    const isRootModal = invokerContainer.modalType === "root";
     await render(
       React.createElement(this.messageCache.get(invokerContainer.name) as any, {
         useState,
         props: invokerContainer.props,
         useModal,
         user: invokerContainer.type === "home" ? payload.user : undefined,
-      }), {
+      }), !isRootModal ? undefined : {
         value: undefined,
         event: {
           form,

--- a/src/core/phelia.ts
+++ b/src/core/phelia.ts
@@ -186,7 +186,7 @@ export class Phelia {
     );
   }
 
-  registerComponents(components: PheliaMessage[]) {
+  registerComponents(components: (PheliaMessage | PheliaModal)[]) {
     const pheliaComponents = loadMessagesFromArray(components);
 
     this.messageCache = pheliaComponents.reduce(
@@ -812,7 +812,7 @@ export class Phelia {
 
   messageHandler(
     signingSecret: string,
-    messages?: string | PheliaMessage[] | PheliaModal[] | MessageCallback,
+    messages?: string | (PheliaModal | PheliaMessage)[] | MessageCallback,
     home?: PheliaMessage,
     slackOptions?: MessageAdapterOptions
   ) {

--- a/src/core/reconciler.ts
+++ b/src/core/reconciler.ts
@@ -221,6 +221,22 @@ class HostConfig
       return true;
     }
 
+    if (rootContainerInstance.action?.type === "onsubmit" && props.onSubmit) {
+      rootContainerInstance.promises.push(
+        props.onSubmit(rootContainerInstance.action.event)
+      );
+
+      return true;
+    }
+
+    if (rootContainerInstance.action?.type === "oncancel" && props.onCancel) {
+      rootContainerInstance.promises.push(
+        props.onCancel(rootContainerInstance.action.event)
+      );
+
+      return true;
+    }
+
     if (
       rootContainerInstance.action &&
       props.action === rootContainerInstance.action.value


### PR DESCRIPTION
This diff adds the ability to open up a modal using a `trigger_id` passed from some action like a command from inside slack.  

I do so by adding two new optional props to the `Modal` component: `onSubmit` and `onCancel` that are run on submission of a modal.  If the model was triggered by a `useModal` function, then `onSubmit` and `onCancel` will run in both the `Modal` component and the `useModal` callbacks.

I'm not really sure if this is the correct approach, it felt the most natural after a little discovery in the reconciler.  Looking for feedback on method here, some discussion as to whether the author would like to merge this (I see this and ephemeral messages as the two small missing features), and how I might be able to adjust to merge. 

I've tested the basic functionality in an application I'm building, but have done little verification past that. 

