### PR TITLE
[Feature] Add ephemeral message support

### DIFF
--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -129,6 +129,8 @@ export interface PheliaMessageContainer {
   ts: string;
   /** The type of phelia component surface */
   type: "message" | "modal" | "home";
+  /** When `type` === message: whether the message is ephemeral or not */
+  isEphemeral?: true;
   /** An id for the surface */
   viewID: string;
   /** A user who interacts with the message */

--- a/src/core/phelia.ts
+++ b/src/core/phelia.ts
@@ -95,6 +95,61 @@ export class Phelia {
     return messageKey;
   }
 
+  async postEphemeral<p>(
+    message: PheliaMessage<p>,
+    channel: string,
+    props: p = null,
+  ): Promise<string> {
+    const initializedState: { [key: string]: any } = {};
+
+    /** A hook to create some state for a component */
+    function useState<t>(
+      key: string,
+      initialValue?: t
+    ): [t, (value: t) => void] {
+      initializedState[key] = initialValue;
+      return [initialValue, (_: t): void => null];
+    }
+
+    /** A hook to create a modal for a component */
+    function useModal(): (title: string, props?: any) => Promise<void> {
+      return async () => null;
+    }
+
+    const messageData = await render(
+      React.createElement(message, { useState, props, useModal })
+    );
+
+    // only can return a user id here, need to enhance it using methods.user
+    const {
+      channel: channelID,
+      ts,
+      message: sentMessageData,
+    } = await this.client.chat.postEphemeral({
+      ...messageData,
+      channel,
+    });
+
+    const messageKey = `${channelID}:${ts}`;
+
+    await Phelia.Storage.set(
+      messageKey,
+      JSON.stringify({
+        message: JSON.stringify(messageData),
+        type: "message",
+        isEphemeral: true,
+        name: message.name,
+        state: initializedState,
+        user: { id: (sentMessageData as any).user },
+        props,
+        channelID,
+        ts,
+      })
+    );
+
+    return messageKey;
+  }
+
   async updateMessage<p>(key: string, props: p) {
     const rawMessageContainer = await Phelia.Storage.get(key);
     if (!rawMessageContainer) {
@@ -102,6 +157,10 @@ export class Phelia {
     }
 
     const container: PheliaMessageContainer = JSON.parse(rawMessageContainer);
+
+    if (container.isEphemeral === true) {
+      throw TypeError("Ephemeral messages cannot be updated.");
+    }
 
     /** A hook to create some state for a component */
     function useState<t>(key: string): [t, (value: t) => void] {

--- a/src/core/phelia.ts
+++ b/src/core/phelia.ts
@@ -98,6 +98,7 @@ export class Phelia {
   async postEphemeral<p>(
     message: PheliaMessage<p>,
     channel: string,
+    user: string,
     props: p = null,
   ): Promise<string> {
     const initializedState: { [key: string]: any } = {};
@@ -127,6 +128,7 @@ export class Phelia {
       message: sentMessageData,
     } = await this.client.chat.postEphemeral({
       ...messageData,
+      user,
       channel,
     });
 


### PR DESCRIPTION
As the title describes.  This is mostly copypasta, with the added small nuance that use of `updateMessage` is disallowed, as Slack only allows ephemeral messages to be updated by interactions with those messages themselves.

## Test plan

I've basically validated this approach by ensuring it works with a non-error code back from Slack.  I'll need to double check that a message update works okay, as I've essentially assumed that `chat.update` works (i.e. what currently exists works with no modifications) fine on these messages provided it's an interaction with the message itself.