### PR TITLE
Only send `initial_options` for `multi_static_select` when present

### DIFF
--- a/src/core/components.tsx
+++ b/src/core/components.tsx
@@ -1295,7 +1295,9 @@ export const MultiSelectMenu = (props: MultiSelectMenuProps) => (
           }))
           .filter((option) => option?.isSelected());
 
-        instance.initial_options = selectedOptions;
+        if (selectedOptions.length) {
+          instance.initial_options = selectedOptions;
+        }
       }
 
       if (props.type === "external") {

--- a/src/tests/__snapshots__/reconciler.spec.tsx.snap
+++ b/src/tests/__snapshots__/reconciler.spec.tsx.snap
@@ -1038,7 +1038,6 @@ exports[`Multi Static Select Menu Multi Static Select Menu with one option group
 Object {
   "action_id": "select",
   "confirm": undefined,
-  "initial_options": Array [],
   "max_selected_items": undefined,
   "onSearchOptions": undefined,
   "option_groups": Array [
@@ -1075,7 +1074,6 @@ exports[`Multi Static Select Menu Multi Static Select Menu with one option rende
 Object {
   "action_id": "select",
   "confirm": undefined,
-  "initial_options": Array [],
   "max_selected_items": undefined,
   "onSearchOptions": undefined,
   "options": Array [
@@ -1223,7 +1221,6 @@ exports[`Multi Static Select Menu Multi Static Select Menu with two option group
 Object {
   "action_id": "select",
   "confirm": undefined,
-  "initial_options": Array [],
   "max_selected_items": undefined,
   "onSearchOptions": undefined,
   "option_groups": Array [
@@ -1280,7 +1277,6 @@ exports[`Multi Static Select Menu Multi Static Select Menu with two options rend
 Object {
   "action_id": "select",
   "confirm": undefined,
-  "initial_options": Array [],
   "max_selected_items": undefined,
   "onSearchOptions": undefined,
   "options": Array [


### PR DESCRIPTION
Hello there! Great job with Phelia!

We were updating an internal slack app we have to use Phelia and we noticed an issue with `MultiSelect`.
We currently have a `multi_static_select` that we setup with no initially selected options. When we updated the input to a static `MultiSelect` we started seeing error responses from the Slack API like:

```
[app] handling: /interactions
[ERROR]  WebClient:0 must be one of the provided options [json-pointer:view/blocks/0/element/initial_options]
(node:41156) UnhandledPromiseRejectionWarning: Error: An API error occurred: invalid_arguments
    at Object.platformErrorFromResult (/Users/sedunn/Projects/Work/behance-slack-app/node_modules/@slack/web-api/dist/errors.js:50:33)
    at WebClient.apiCall (/Users/sedunn/Projects/Work/behance-slack-app/node_modules/@slack/web-api/dist/WebClient.js:485:28)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

After some experimentation with the existing json we send, I discovered the issue! The Slack API doesn't handle an empty array for static `intial_options` gracefully. The simplest fix seemed to be wrapping a guard around setting the `initial_options` for when the selected options filters to an empty array.

Thanks again for the great work!