### PR TITLE
fix: set initialOption for static select menu

### DIFF
--- a/src/core/components.tsx
+++ b/src/core/components.tsx
@@ -1089,7 +1089,13 @@ export const SelectMenu = (props: SelectMenuProps) => (
           }))
           .find((option) => option?.isSelected());
 
-        instance.initial_option = selectedOption;
+        if (selectedOption) {
+          instance.initial_option = selectedOption;
+        } else if (initialOption) {
+          instance.initial_option = { ...initialOption, url: undefined };
+        } else {
+          instance.initial_option = undefined;
+        }
       }
 
       if (props.type === "external") {

--- a/src/tests/__snapshots__/reconciler.spec.tsx.snap
+++ b/src/tests/__snapshots__/reconciler.spec.tsx.snap
@@ -2089,6 +2089,54 @@ Object {
 }
 `;
 
+exports[`Static Select Menu Static Select Menu with two options and one initial option renders a Static Select Menu with two options 1`] = `
+Object {
+  "action_id": "select",
+  "confirm": undefined,
+  "initial_option": Object {
+    "description": undefined,
+    "isOption": [Function],
+    "isSelected": [Function],
+    "text": Object {
+      "text": "Option 2",
+      "type": "plain_text",
+    },
+    "url": undefined,
+    "value": "2",
+  },
+  "onSearchOptions": undefined,
+  "options": Array [
+    Object {
+      "description": undefined,
+      "isOption": [Function],
+      "isSelected": [Function],
+      "text": Object {
+        "text": "Option 1",
+        "type": "plain_text",
+      },
+      "url": undefined,
+      "value": "1",
+    },
+    Object {
+      "description": undefined,
+      "isOption": [Function],
+      "isSelected": [Function],
+      "text": Object {
+        "text": "Option 2",
+        "type": "plain_text",
+      },
+      "url": undefined,
+      "value": "2",
+    },
+  ],
+  "placeholder": Object {
+    "text": "a placeholder",
+    "type": "plain_text",
+  },
+  "type": "static_select",
+}
+`;
+
 exports[`Static Select Menu Static Select Menu with two options renders a Static Select Menu with two options 1`] = `
 Object {
   "action_id": "select",

--- a/src/tests/reconciler.spec.tsx
+++ b/src/tests/reconciler.spec.tsx
@@ -1133,6 +1133,24 @@ describe("Static Select Menu", () => {
     });
   });
 
+  describe("Static Select Menu with two options and one initial option", () => {
+    const component = () => (
+      <SelectMenu
+        placeholder="a placeholder"
+        action="select"
+        initialOption={<Option value="2">Option 2</Option>}
+      >
+        <Option value="1">Option 1</Option>
+        <Option value="2">Option 2</Option>
+      </SelectMenu>
+    );
+
+    it("renders a Static Select Menu with two options", async () => {
+      const blocks = await render(React.createElement(component));
+      expect(blocks).toMatchSnapshot();
+    });
+  });
+
   describe("Static Select Menu with selected option", () => {
     const component = () => (
       <SelectMenu placeholder="a placeholder" action="select">


### PR DESCRIPTION
This wasn't previously being set. I kept initial_option=undefined
because I wanted to keep the old jest specs working, and it looks
like most of them had undefined values for other props, too.